### PR TITLE
use datetime.utcnow() instead of datetime.now() fixing issue #1

### DIFF
--- a/lib/ranking/reports.py
+++ b/lib/ranking/reports.py
@@ -27,7 +27,7 @@ from sqlalchemy import and_, desc
 
 class Reports():
     
-    def __init__(self, date = datetime.datetime.now()):
+    def __init__(self, date = datetime.datetime.utcnow()):
         self.date = date
         self.impacts = {}
         for item in items:

--- a/website/master_controler.py
+++ b/website/master_controler.py
@@ -12,7 +12,7 @@ from graph_generator import GraphGenerator
 
 class MasterControler():
 
-    def __init__(self, date = datetime.datetime.now()):
+    def __init__(self, date = datetime.datetime.utcnow()):
         self.report = Reports(date)
 
     def prepare_index(self, source = None, limit = 50):


### PR DESCRIPTION
This fixes issue #1 by making the ranking system uses UTC time just like the database timestamps do.
